### PR TITLE
added phpmetrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@
      <h2>Jenkins PHP</h2>
      <p>The goal of the <a href="http://jenkins-php.org/">Template for Jenkins Jobs for PHP Projects</a> is to provide a standard template for Jenkins (the leading open-source <a href="http://martinfowler.com/articles/continuousIntegration.html">continuous integration</a> server) jobs for PHP projects.</p>
     </div>
+    <div class="col-md-4">
+     <h2>PhpMetrics</h2>
+     <p><a href="http://phpmetrics.org/">PhpMetrics</a> is a static analyzer tool. It provides a large set of <a href="http://en.wikipedia.org/wiki/Software_metric">software metrics</a> from a given code base. PhpMetrics generates readable and accessible reports about maintainability, quality and complexity of a source code.</p>
+    </div>
    </div>
    <hr>
    <footer>


### PR DESCRIPTION
Hi @sebastianbergmann,

[PhpMetrics](https://github.com/Halleck45/PhpMetrics) is a static analyzer for PHP.

Like PhpDepend or PhpLoc, this tool provides Abstractness, (a/e)fferent Coupling, Lines of code... But PhpMetrics provides lot of other metrics:

+ Halstead metrics (volume, effort, vocabulary...)
+ Maintainability index
+ Card and Agresti metrics (Relative/absolute system/data complexity...)
+ Lack of cohesion of methods
+ Myer's metrics (Interval, Distance)
+ ...

PhpMetrics has many contributors (26), and begins to have a good community.

I think (hope) that the presence of PhpMetrics on qatools.org is legitimate and can help PHP developers to improve the quality of their projects :)

Thanks !