### PR TITLE
Add GrumPHP to the QA Toolchain.

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,12 @@
      <p><a href="http://www.qa-tools.io/">QA-Tools</a> is a library, that makes acceptance test writing a breeze through <a href="http://www.qa-tools.io/PageObject-pattern/">PageObject pattern</a> usage in the tests.</p>
     </div>
    </div>
+   <div class="row">
+    <div class="col-md-4">
+     <h2>GrumPHP</h2>
+     <p><a href="https://github.com/phpro/grumphp">GrumPHP</a> is a quality assurance tool, that hooks in on your commits. You can configure a list of built-in tasks that run on the code before it is committed. When one of the tasks fail, you won't be able to commit your code. This way, only clean code can enter your GIT repository.</p>
+    </div>
+   </div>
    <hr>
    <footer>
     <div align="center"><p>The <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type"><a xmlns:cc="http://creativecommons.org/ns#" href="http://phpqatools.org/" property="cc:attributionName" rel="cc:attributionURL">content of this website</a></span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.</p></div>


### PR DESCRIPTION
Hello,

I've added a tool named GrumPHP to the QA toolchain:

GrumPHP is a quality assurance tool, that hooks in on your commits. You can configure a list of built-in tasks that run on the code before it is committed. When one of the tasks fail, you won't be able to commit your code. This way, only clean code can enter your GIT repository.

Feel free to check it out at:
https://github.com/phpro/grumphp