### PR TITLE
phpqatools.org domain is being used for another purposes

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-phpqatools.org

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# phpqatools.org
+
+This website used to be a list, curated by [Sebastian Bergmann](https://sebastian-bergmann.de/), of quality assurance tools for PHP.
+
+This website has been superseded by a community-curated list of static analysis tools for PHP at [exakat/php-static-analysis-tools](https://github.com/exakat/php-static-analysis-tools) on GitHub.
+
+If you need support with the selection and adoption of suitable tools to improve your PHP development process then [thePHP.cc](https://thephp.cc/implementation/tools) can help you.


### PR DESCRIPTION
Hi Sebastian

I was looking to a presentation that refers to phpqatools.org. Somebody has bought the domain and put a blog in there. The first article title is something like "XXX actresses ..." so doesn't make any sense to create traffic for something not PHP or QA related

I copy your deprecation notice to the README.md so it can be easily notice when you enter into github. Also, please remove the link a the beginning of the repo to avoid sending more traffic to this new place
